### PR TITLE
Fix crashloop golang:alpine

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "First Docker build-stage is now done"
 
 FROM gcr.io/distroless/base as prod
 
-FROM golang:alpine as test
+FROM golang:stretch as test
 
 FROM golang:stretch as local
 


### PR DESCRIPTION
Fix standard_init_linux.go:219: exec user process caused: no such file or directory

#### What changes does this PR contain?

#### Which JIRA ticket ID's are associated with this PR?

#### Additional comments and information
